### PR TITLE
Conversions into display currency when transferring

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -163,7 +163,7 @@ export default class App extends Component {
     const { exchangeRate } = this.state
     const locale = localStorage.getItem('i18nextLng') 
     const symbol = localStorage.getItem('currency') || Object.keys(exchangeRate)[0];
-    const convertedAmount = this.convertExchangeRate(amount);
+    const convertedAmount = this.fromDollars(amount);
 
     return new Intl.NumberFormat(locale, {
       style: 'currency',
@@ -172,14 +172,20 @@ export default class App extends Component {
     }).format(convertedAmount)
   }
 
-  // NOTE: This function is for telling a computer the converted value between
-  // two currencies. Please do not use this function to display values to
-  // users but use `currencyDisplay`.
-  convertExchangeRate = amount => {
+  // `fromDollars` and `toDollars` is used to convert floats from one currency
+  // to another without adding a currency unit symbol.
+  fromDollars = amount => {
     const { exchangeRate } = this.state
     const rate = Object.values(exchangeRate)[0];
 
     return amount * rate;
+  }
+
+  toDollars = amount => {
+    const { exchangeRate } = this.state
+    const rate = Object.values(exchangeRate)[0];
+
+    return amount / rate;
   }
 
   parseAndCleanPath(path){
@@ -1013,6 +1019,8 @@ export default class App extends Component {
                             ethBalance={this.state.ethBalance}
                             changeView={this.changeView.bind(this)}
                             setReceipt={this.setReceipt.bind(this)}
+                            currencyDisplay={this.currencyDisplay}
+                            toDollars={this.toDollars}
                           />
                         </Card>
                         <Bottom
@@ -1103,6 +1111,7 @@ export default class App extends Component {
                           changeAlert={this.changeAlert}
                           convertExchangeRate={this.convertExchangeRate}
                           currencyDisplay={this.currencyDisplay}
+                          toDollars={this.toDollars}
                         />
                       </Card>
                       <Bottom
@@ -1190,6 +1199,7 @@ export default class App extends Component {
                             changeView={this.changeView}
                             changeAlert={this.changeAlert}
                             currencyDisplay={this.currencyDisplay}
+                            toDollars={this.toDollars}
                             transactionsByAddress={this.state.transactionsByAddress}
                             fullTransactionsByAddress={this.state.fullTransactionsByAddress}
                             fullRecentTxs={this.state.fullRecentTxs}
@@ -1327,6 +1337,7 @@ export default class App extends Component {
                           balance={balance}
                           goBack={this.goBack.bind(this)}
                           currencyDisplay={this.currencyDisplay}
+                          toDollars={this.toDollars}
                           tokenSendV2={tokenSendV2.bind(this)}
                         />
                       </Card>

--- a/src/components/Bity.js
+++ b/src/components/Bity.js
@@ -114,8 +114,10 @@ class Bity extends Component {
 
   async cashout() {
     const { IBAN } = this.validate("IBAN")();
-    const { metaAccount } = this.state;
-    const { name } = this.state.fields;
+    const {
+      metaAccount,
+      fields: { name }
+    } = this.state;
     const {
       address,
       ethPrice,

--- a/src/components/Bity.js
+++ b/src/components/Bity.js
@@ -115,7 +115,7 @@ class Bity extends Component {
   async cashout() {
     const { IBAN } = this.validate("IBAN")();
     const { metaAccount } = this.state;
-    const { name, amount } = this.state.fields;
+    const { name } = this.state.fields;
     const {
       address,
       ethPrice,
@@ -123,12 +123,17 @@ class Bity extends Component {
       web3,
       changeView,
       setReceipt,
-      changeAlert
+      changeAlert,
+      toDollars
     } = this.props;
+    let { amount } = this.state.fields;
+
     if (IBAN.valid) {
       changeView("loader_ROOTCHAIN");
 
       let order;
+
+      amount.value = toDollars(amount.value);
       const amountInEth = (amount.value / ethPrice).toString();
       try {
         order = await placeOrder(
@@ -313,16 +318,16 @@ class Bity extends Component {
         });
       } else if (input === "amount") {
         const amount = parseFloat(this.refs.amount.value);
-        const { ethPrice, ethBalance } = this.props;
+        const { ethPrice, ethBalance, currencyDisplay } = this.props;
         const min = MIN_AMOUNT_DOLLARS;
         const max = parseFloat(ethPrice) * parseFloat(ethBalance);
 
         let valid, message;
         if (amount < min) {
           valid = false;
-          message = `${i18n.t(
-            "offramp.amount_too_small"
-          )} $${MIN_AMOUNT_DOLLARS}.`;
+          message = `${i18n.t("offramp.amount_too_small")} ${currencyDisplay(
+            MIN_AMOUNT_DOLLARS
+          )}.`;
         } else if (amount > max) {
           valid = false;
           message = i18n.t("offramp.amount_too_big");
@@ -345,6 +350,8 @@ class Bity extends Component {
 
   render() {
     const { fields } = this.state;
+    const { currencyDisplay } = this.props;
+
     return (
       <div>
         <Box mb={4}>
@@ -400,7 +407,7 @@ class Bity extends Component {
                   ? "grey"
                   : "red"
               }
-              placeholder="$0.00"
+              placeholder={currencyDisplay(0)}
             />
             {fields.amount.message ? (
               <Error>{fields.amount.message}</Error>

--- a/src/components/History.js
+++ b/src/components/History.js
@@ -169,7 +169,6 @@ export default class History extends React.Component {
 
     let txns = []
     for(let r in theseTransactionsByAddress){
-      console.log(r);
 
       let messageValue = ""
       let value = parseFloat(theseTransactionsByAddress[r].value)

--- a/src/components/RequestFunds.js
+++ b/src/components/RequestFunds.js
@@ -31,7 +31,10 @@ export default class RequestFunds extends React.Component {
 
   request = () => {
     if(this.state.canRequest){
-      this.setState({requested:true})
+      this.setState({
+        requested:true,
+        amount: this.props.toDollars(this.state.amount)
+      })
     }else{
       this.props.changeAlert({type: 'warning', message: 'Please enter a valid amount'})
     }
@@ -39,7 +42,7 @@ export default class RequestFunds extends React.Component {
 
   render() {
     let { canRequest, message, amount, requested } = this.state;
-    let {currencyDisplay,view,buttonStyle,ERC20TOKEN,address, changeView} = this.props
+    let { currencyDisplay, view, buttonStyle, address, changeView } = this.props
     if(requested){
 
       let url = window.location.protocol+"//"+window.location.hostname
@@ -70,13 +73,6 @@ export default class RequestFunds extends React.Component {
               <Input type='url' readOnly value={qrValue} width={1} />
             </Box>
 
-            {/* <div className="input-group">
-              <input type="text" className="form-control" value={qrValue} disabled/>
-              <div className="input-group-append">
-                <span className="input-group-text"><i className="fas fa-copy"/></span>
-              </div>
-            </div> */}
-
             </div>
           </CopyToClipboard>
           <RecentTransactions
@@ -84,12 +80,11 @@ export default class RequestFunds extends React.Component {
             view={view}
             max={5}
             buttonStyle={buttonStyle}
-            ERC20TOKEN={ERC20TOKEN}
-            transactionsByAddress={ERC20TOKEN?this.props.fullTransactionsByAddress:this.props.transactionsByAddress}
+            transactionsByAddress={this.props.transactionsByAddress}
             changeView={changeView}
             address={address}
             block={this.props.block}
-            recentTxs={ERC20TOKEN?this.props.fullRecentTxs:this.props.recentTxs}
+            recentTxs={this.props.recentTxs}
           />
         </div>
       )
@@ -100,7 +95,7 @@ export default class RequestFunds extends React.Component {
             <Input
               type="number"
               width={1}
-              placeholder="$0.00"
+              placeholder={this.props.currencyDisplay(0)}
               value={this.state.amount}
               onChange={event => this.updateState('amount', event.target.value)}
             />

--- a/src/components/SendToAddress.js
+++ b/src/components/SendToAddress.js
@@ -119,9 +119,9 @@ export default class SendToAddress extends React.Component {
 
   send = async () => {
     let { toAddress, amount } = this.state;
-    let { convertExchangeRate, currencyDisplay } = this.props
+    let { toDollars, currencyDisplay } = this.props
 
-    amount = convertExchangeRate(amount);
+    amount = toDollars(amount);
     console.log("CONVERTED TO DOLLAR AMOUNT",amount)
 
     if(this.state.canSend){
@@ -227,7 +227,7 @@ export default class SendToAddress extends React.Component {
       <Input
         width={1}
         type="number"
-        placeholder="$0.00"
+        placeholder={this.props.currencyDisplay(0)}
         value={this.state.amount}
         ref={(input) => { this.amountInput = input; }}
         onChange={event => this.updateState('amount', event.target.value)}
@@ -239,7 +239,7 @@ export default class SendToAddress extends React.Component {
           width={1}
           type="number"
           readOnly
-          placeholder="$0.00"
+          placeholder={this.props.currencyDisplay(0)}
           value={this.state.amount}
           ref={(input) => { this.amountInput = input; }}
           onChange={event => this.updateState('amount', event.target.value)}


### PR DESCRIPTION
Fixes #196 

What has been done:

- Introduces two new methods `fromDollars` and `toDollars` that can convert respective "Display values"
- For all `<Input />` the user's inserts, the value is correctly converted

Problems that were discovered:

- "Include currency into <RequestFunds /> QR Code" https://github.com/leapdao/plasma-burner-wallet/issues/200

