### PR TITLE
Include currency into <RequestFunds /> QR Code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10026,13 +10026,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -10045,18 +10043,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -10159,8 +10154,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -10170,7 +10164,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -10183,20 +10176,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -10213,7 +10203,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -10286,8 +10275,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -10297,7 +10285,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -10403,7 +10390,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "react-native-webview-messaging": "^1.2.3",
     "react-qr-reader": "^2.1.1",
     "react-scroll": "^1.7.10",
-    "rimble-ui": "^0.4.2",
+    "rimble-ui": "0.4.2",
     "styled-components": "^4.1.3",
     "web3": "1.0.0-beta.36"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -161,17 +161,20 @@ export default class App extends Component {
 
   // NOTE: This function is for _displaying_ a currency value to a user. It
   // adds a currency unit to the beginning or end of the number!
-  currencyDisplay(amount, toParts) {
+  currencyDisplay(amount, toParts=false, convert=true) {
     const locale = localStorage.getItem('i18nextLng') 
     const symbol = localStorage.getItem('currency');
-    const convertedAmount = this.convertCurrency(amount, `${symbol}/USD`);
+
+    if (convert) {
+      amount = this.convertCurrency(amount, `${symbol}/USD`);
+    }
 
     const formatter = new Intl.NumberFormat(locale, {
       style: 'currency',
       currency: symbol,
       maximumFractionDigits: 2
     });
-    return toParts ? formatter.formatToParts(convertedAmount) : formatter.format(convertedAmount);
+    return toParts ? formatter.formatToParts(amount) : formatter.format(amount);
   }
 
   /*

--- a/src/App.js
+++ b/src/App.js
@@ -129,9 +129,9 @@ export default class App extends Component {
       ethprice: 0.00,
       hasUpdateOnce: false,
       possibleNewPrivateKey: '',
-      // NOTE: USD in exchangeRate is undefined, such that any result using this
+      // NOTE: USD in exchangeRates is undefined, such that any result using this
       // number becomes NaN intentionally until it's defined.
-      exchangeRate: {}
+      exchangeRates: {}
     };
     this.alertTimeout = null;
 
@@ -195,11 +195,11 @@ export default class App extends Component {
    * NOTE: This function assumes 1 DAI = 1 USD!
    */
   convertCurrency(amount, pair) {
-    const { exchangeRate } = this.state;
+    const { exchangeRates } = this.state;
     const [base, counter] = pair.split("/");
 
-    const baseRate = exchangeRate[base];
-    const counterRate = exchangeRate[counter];
+    const baseRate = exchangeRates[base];
+    const counterRate = exchangeRates[counter];
 
     return baseRate / counterRate * amount;
   }
@@ -407,7 +407,7 @@ export default class App extends Component {
     // 1 DAI == 1 USD. In numeris veritas!
     pairs.USD = 1;
 
-    this.setState({ exchangeRate: pairs });
+    this.setState({ exchangeRates: pairs });
   }
 
   setPossibleNewPrivateKey(value){

--- a/src/App.js
+++ b/src/App.js
@@ -90,7 +90,6 @@ const MAX_BLOCK_TO_LOOK_BACK = 512//don't look back more than 512 blocks
 
 let interval
 let intervalLong
-let exchangeRatesQueryTimer
 
 const Warning = styled(Text).attrs(()=>({
   fontSize: 2,
@@ -332,7 +331,6 @@ export default class App extends Component {
     // NOTE: We query once before starting the interval to define the value
     // for the UI, as it needs to be readily available for the user.
     this.queryExchangeWithNativeCurrency(CONFIG.CURRENCY.EXCHANGE_RATE_QUERY);
-    exchangeRatesQueryTimer = setInterval(this.queryExchangeWithNativeCurrency, CONFIG.CURRENCY.EXCHANGE_RATE_QUERY)
     setTimeout(this.longPoll,150)
 
     this.connectToRPC()
@@ -352,7 +350,6 @@ export default class App extends Component {
   componentWillUnmount() {
     clearInterval(interval)
     clearInterval(intervalLong)
-    clearInterval(exchangeRatesQueryTimer)
     window.removeEventListener("resize", this.updateDimensions.bind(this));
   }
 

--- a/src/components/Advanced.js
+++ b/src/components/Advanced.js
@@ -8,7 +8,6 @@ import {
   Text,
   Select,
   Flex,
-  Box,
   Checkbox
 } from 'rimble-ui'
 import { PrimaryButton, BorderButton } from '../components/Buttons'

--- a/src/components/Bity.js
+++ b/src/components/Bity.js
@@ -125,8 +125,7 @@ class Bity extends Component {
       web3,
       changeView,
       setReceipt,
-      changeAlert,
-      toDollars
+      changeAlert
     } = this.props;
     let { amount } = this.state.fields;
 
@@ -135,7 +134,8 @@ class Bity extends Component {
 
       let order;
 
-      amount.value = toDollars(amount.value);
+      // NOTE: We've converted amount while the user was typing already to USD.
+      // Hence, there's not need to do anything here!
       const amountInEth = (amount.value / ethPrice).toString();
       try {
         order = await placeOrder(
@@ -319,8 +319,19 @@ class Bity extends Component {
           }
         });
       } else if (input === "amount") {
-        const amount = parseFloat(this.refs.amount.value);
-        const { ethPrice, ethBalance, currencyDisplay } = this.props;
+        const {
+          ethPrice,
+          ethBalance,
+          currencyDisplay,
+          convertCurrency
+        } = this.props;
+
+        const displayCurrency = localStorage.getItem("currency");
+        const amount = convertCurrency(
+          parseFloat(this.refs.amount.value),
+          `USD/${displayCurrency}`
+        );
+
         const min = MIN_AMOUNT_DOLLARS;
         const max = parseFloat(ethPrice) * parseFloat(ethBalance);
 

--- a/src/components/Bity.js
+++ b/src/components/Bity.js
@@ -8,15 +8,10 @@ import styled from "styled-components";
 import { isValid } from "iban";
 import { placeOrder, getOrder, getEstimate } from "../services/bity";
 import { price } from "../services/ethgasstation";
+import InputInfo from "./InputInfo";
 
 const P = styled.p`
   color: gray;
-`;
-
-const Error = styled.span`
-  padding: 6px 0 0 0;
-  color: red;
-  font-size: 0.7em;
 `;
 
 // See: https://doc.bity.com/exchange/v2.html#place-an-order
@@ -393,7 +388,9 @@ class Bity extends Component {
                 fields.name.valid === null || fields.name.valid ? "grey" : "red"
               }
             />
-            {fields.name.message ? <Error>{fields.name.message}</Error> : null}
+            {fields.name.message ? (
+              <InputInfo color="red">{fields.name.message}</InputInfo>
+            ) : null}
           </Field>
           <Field mb={3} label="IBAN">
             <Input
@@ -407,7 +404,9 @@ class Bity extends Component {
                 fields.IBAN.valid === null || fields.IBAN.valid ? "grey" : "red"
               }
             />
-            {fields.IBAN.message ? <Error>{fields.IBAN.message}</Error> : null}
+            {fields.IBAN.message ? (
+              <InputInfo color="red">{fields.IBAN.message}</InputInfo>
+            ) : null}
           </Field>
           <Field mb={3} label={i18n.t("offramp.form.amount")}>
             <Input
@@ -423,7 +422,7 @@ class Bity extends Component {
               placeholder={currencyDisplay(0)}
             />
             {fields.amount.message ? (
-              <Error>{fields.amount.message}</Error>
+              <InputInfo color="red">{fields.amount.message}</InputInfo>
             ) : null}
           </Field>
         </Box>

--- a/src/components/Exchange.js
+++ b/src/components/Exchange.js
@@ -279,7 +279,7 @@ export default class Exchange extends React.Component {
   }
   async sendDai(){
     let { daiContract } = this.props;
-    const { pTx, changeAlert, daiBalance, web3, toDollars } = this.props;
+    const { pTx, changeAlert, daiBalance, web3, convertCurrency} = this.props;
     const {
       daiAddress,
       daiSendToAddress,
@@ -288,8 +288,9 @@ export default class Exchange extends React.Component {
     } = this.state;
     let { daiSendAmount } = this.state;
 
+    const displayCurrency = localStorage.getItem("currency");
     // NOTE: daiSendAmount needs to be a string!
-    daiSendAmount = ""+toDollars(daiSendAmount);
+    daiSendAmount = `${convertCurrency(daiSendAmount, `USD/${displayCurrency}`)}`;
 
     if(parseFloat(daiBalance)<parseFloat(daiSendAmount)){
       changeAlert({type: 'warning',message: i18n.t('exchange.insufficient_funds')});
@@ -543,11 +544,12 @@ export default class Exchange extends React.Component {
       ethBalance,
       changeAlert,
       web3,
-      toDollars
+      convertCurrency
     } = this.props;
     let { ethSendAmount } = this.state;
 
-    ethSendAmount = toDollars(ethSendAmount);
+    const displayCurrency = localStorage.getItem("currency");
+    ethSendAmount = convertCurrency(ethSendAmount, `USD/${displayCurrency}`);
     let actualEthSendAmount = parseFloat(ethSendAmount)/parseFloat(ethprice)
 
     if(parseFloat(ethBalance)<actualEthSendAmount){
@@ -802,7 +804,9 @@ export default class Exchange extends React.Component {
               className={"btn-send"}
               disabled={buttonsDisabled}
               onClick={()=>{
-                console.log("AMOUNT:",this.state.amount,"DAI BALANCE:",this.props.daiBalance)
+                let { amount } = this.state;
+                const { convertCurrency } = this.props;
+                console.log("AMOUNT:", amount,"DAI BALANCE:",this.props.daiBalance)
 
                 this.setState({
                   daiToXdaiMode:"depositing",
@@ -817,7 +821,8 @@ export default class Exchange extends React.Component {
                   }
                 })
 
-                const amount = this.props.toDollars(this.state.amount);
+                const displayCurrency = localStorage.getItem("currency");
+                amount = convertCurrency(amount, `USD/${displayCurrency}`);
                 // TODO: depositDai doesn't use the destination parameter anymore
                 // Remove it.
                 this.depositDai(null, amount, "Sending funds to bridge...", () => {
@@ -867,11 +872,15 @@ export default class Exchange extends React.Component {
             </div>
             {daiCancelButton}
             <PrimaryButton className={"btn-send"} disabled={buttonsDisabled} onClick={async ()=>{
-              console.log("AMOUNT:",this.state.amount,"DAI BALANCE:",this.props.daiBalance)
+                const { convertCurrency } = this.props;
+                let { amount } = this.state;
+
                 // First we convert from the current display value and
-                let amount = this.props.toDollars(this.state.amount);
+                const displayCurrency = localStorage.getItem("currency");
+                amount = convertCurrency(amount, `USD/${displayCurrency}`);
+
                 // Then we convert that value to wei
-                amount = bi(this.state.amount * 10 ** 18);
+                amount = bi(amount * 10 ** 18);
 
                 if(this.state.xdaiMetaAccount){
                   //send funds using metaaccount on xdai
@@ -1014,13 +1023,18 @@ export default class Exchange extends React.Component {
             {ethCancelButton}
             <PrimaryButton disabled={buttonsDisabled} onClick={async ()=>{
               console.log("Using uniswap exchange to move ETH to DAI")
+              const { convertCurrency } = this.props;
+              let { amount } = this.state;
 
               let webToUse = this.props.web3
               if(this.state.mainnetMetaAccount){
                 webToUse = this.state.mainnetweb3
               }
 
-              const amount = this.props.toDollars(this.state.amount);
+              // TODO: Error: Returned values aren't valid, did it run Out of Gas?
+              const displayCurrency = localStorage.getItem("currency");
+              amount = convertCurrency(amount, `USD/${displayCurrency}`);
+
               console.log("AMOUNT:", amount, "DAI BALANCE:", this.props.daiBalance)
 
               let uniswapContract = new webToUse.eth.Contract(uniswapContractObject.abi,uniswapContractObject.address)
@@ -1117,13 +1131,17 @@ export default class Exchange extends React.Component {
             {ethCancelButton}
             <PrimaryButton className="btn-send" disabled={buttonsDisabled} onClick={async ()=>{
               console.log("Using uniswap exchange to move DAI to ETH")
+              const { convertCurrency } = this.props;
+              let { amount } = this.state;
 
               let webToUse = this.props.web3
               if(this.state.mainnetMetaAccount){
                 webToUse = this.state.mainnetweb3
               }
 
-              const amount = this.props.toDollars(this.state.amount);
+              const displayCurrency = localStorage.getItem("currency");
+              amount = convertCurrency(amount, `USD/${displayCurrency}`);
+
               console.log("AMOUNT:", amount, "ETH BALANCE:", this.props.ethBalance)
 
               let uniswapContract = new webToUse.eth.Contract(uniswapContractObject.abi,uniswapContractObject.address)

--- a/src/components/InputInfo.js
+++ b/src/components/InputInfo.js
@@ -1,0 +1,8 @@
+import styled from "styled-components";
+
+// TODO: Open an issue on Consensys/rimble-ui about this feature.
+export default styled.span`
+  padding: 6px 0 0 0;
+  color: ${props => props.color};
+  font-size: 0.7em;
+`;

--- a/src/components/RequestFunds.js
+++ b/src/components/RequestFunds.js
@@ -49,7 +49,12 @@ export default class RequestFunds extends React.Component {
       if(window.location.port&&window.location.port!==80&&window.location.port!==443){
         url = url+":"+window.location.port
       }
-      let qrValue = url+"/"+this.props.address+";"+amount+";"+encodeURI(message).replaceAll("#","%23").replaceAll(";","%3B").replaceAll(":","%3A").replaceAll("/","%2F")
+
+      // TODO: Understand why these `replaceAll`s are used here.
+      message = encodeURI(message).replaceAll("#","%23").replaceAll(";","%3B").replaceAll(":","%3A").replaceAll("/","%2F");
+      const currency = localStorage.getItem("currency");
+
+      let qrValue = url+"/"+this.props.address+";"+amount+";"+message+";"+currency;
 
       return (
         <div>

--- a/src/components/RequestFunds.js
+++ b/src/components/RequestFunds.js
@@ -30,13 +30,16 @@ export default class RequestFunds extends React.Component {
   };
 
   request = () => {
-    if(this.state.canRequest){
+    const { changeAlert } = this.props;
+    const { amount, canRequest } = this.state;
+
+    if(canRequest){
       this.setState({
-        requested:true,
-        amount: this.props.toDollars(this.state.amount)
+        requested: true,
+        amount
       })
     }else{
-      this.props.changeAlert({type: 'warning', message: 'Please enter a valid amount'})
+      changeAlert({type: 'warning', message: 'Please enter a valid amount'})
     }
   };
 
@@ -63,7 +66,10 @@ export default class RequestFunds extends React.Component {
           }}>
           <div style={{width:"100%",textAlign:'center'}}>
             <div style={{fontSize:30,cursor:"pointer",textAlign:"center",width:"100%"}}>
-              {currencyDisplay(amount)}
+              {/* NOTE: We don't need to convert here, as the user already put
+                * in the amount in their local currency.
+                */}
+              {currencyDisplay(amount, false, false)}
             </div>
 
             <div style={{cursor:"pointer",textAlign:"center",width:"100%"}}>

--- a/src/components/RequestFunds.js
+++ b/src/components/RequestFunds.js
@@ -45,7 +45,13 @@ export default class RequestFunds extends React.Component {
 
   render() {
     let { canRequest, message, amount, requested } = this.state;
-    let { currencyDisplay, view, buttonStyle, address, changeView } = this.props
+    let {
+      currencyDisplay,
+      view,
+      buttonStyle,
+      address,
+      changeView,
+    } = this.props
     if(requested){
 
       let url = window.location.protocol+"//"+window.location.hostname
@@ -57,7 +63,7 @@ export default class RequestFunds extends React.Component {
       message = encodeURI(message).replaceAll("#","%23").replaceAll(";","%3B").replaceAll(":","%3A").replaceAll("/","%2F");
       const currency = localStorage.getItem("currency");
 
-      let qrValue = url+"/"+this.props.address+";"+amount+";"+message+";"+currency;
+      const qrValue = `${url}/${address};${amount};${message};${currency}`;
 
       return (
         <div>

--- a/src/components/SendByScan.js
+++ b/src/components/SendByScan.js
@@ -113,6 +113,9 @@ class SendByScan extends Component {
           if (dataSplit.length > 1) {
             returnState.message = dataSplit[2]
           }
+          if (dataSplit.length > 2) {
+            returnState.currency = dataSplit[3]
+          }
           this.props.returnToState(returnState);
         } else {
             // NOTE: Everything that is not a valid Ethereum address, we insert

--- a/src/components/SendToAddress.js
+++ b/src/components/SendToAddress.js
@@ -21,12 +21,32 @@ export default class SendToAddress extends React.Component {
 
     let initialState;
     if (props.scannerState) {
-      const { amount, message, extraMessage, toAddress } = props.scannerState
+      const {
+        scannerState: {
+          message,
+          extraMessage,
+          toAddress,
+          currency
+        },
+        //convertCurrency
+      } = props;
+
+      let { scannerState: { amount } } = props;
+
+      //// NOTE: Two users could have different display currencies, which is why
+      //// at this point we'll have to adjust the requested amount for the user
+      //// sending money.
+      //const displayCurrency = localStorage.getItem("currency");
+      //if (currency !== displayCurrency) {
+      //  amount = convertCurrency(displayCurrency, currency);
+      //}
+
       initialState = {
         amount,
         message,
         extraMessage,
-        toAddress
+        toAddress,
+        currency
       }
     } else {
       const { amount, message, extraMessage } = props
@@ -37,6 +57,7 @@ export default class SendToAddress extends React.Component {
         toAddress: ""
       }
     }
+
 
     initialState.fromEns = ""
     initialState.canSend = false

--- a/src/components/SendToAddress.js
+++ b/src/components/SendToAddress.js
@@ -314,25 +314,27 @@ export default class SendToAddress extends React.Component {
             </CopyToClipboard>
           }</div>
 
-          <Field mb={3} label={i18n.t('send_to_address.send_amount')}>
+          <Field mb={3} label={i18n.t("send_to_address.send_amount")}>
             {amountInputDisplay}
-            {
-              /* TODO: i18n this with merging PR #195 */
-              this.state.currencyWarning ?
-                <InputInfo
-                  color="blue">
-                  You've been requested to send
-                  {" "+new Intl.NumberFormat(localStorage.getItem('i18nextLng'), {
-                    style: 'currency',
+            {/* TODO: i18n this with merging PR #195 */
+            this.state.currencyWarning ? (
+              <InputInfo color="blue">
+                {" "}
+                {`You've been requested to send ${new Intl.NumberFormat(
+                  localStorage.getItem("i18nextLng"),
+                  {
+                    style: "currency",
                     currency: this.state.currency,
                     maximumFractionDigits: 2
-                  }).format(this.state.requestedAmount)}.
-                  We've converted this amount according to our latest known exchange rate to {this.state.displayCurrency}.
-                </InputInfo>
-                : null
-            }
-          </Field>
+                  }
+                ).format(this.state.requestedAmount)}.  We've converted this
+                            amount according to our latest known exchange rate to
+                              ${this.state.displayCurrency}.
 
+                            `}
+              </InputInfo>
+            ) : null}
+          </Field>
           <Field mb={3} label={messageText}>
             <Input
               width={1}

--- a/src/components/SendToAddress.js
+++ b/src/components/SendToAddress.js
@@ -28,18 +28,19 @@ export default class SendToAddress extends React.Component {
           toAddress,
           currency
         },
-        //convertCurrency
+        convertCurrency
       } = props;
 
       let { scannerState: { amount } } = props;
 
-      //// NOTE: Two users could have different display currencies, which is why
-      //// at this point we'll have to adjust the requested amount for the user
-      //// sending money.
-      //const displayCurrency = localStorage.getItem("currency");
-      //if (currency !== displayCurrency) {
-      //  amount = convertCurrency(displayCurrency, currency);
-      //}
+      // NOTE: Two users could have different display currencies, which is why
+      // at this point we'll have to adjust the requested amount for the user
+      // sending money.
+      const displayCurrency = localStorage.getItem("currency");
+      if (currency !== displayCurrency) {
+        amount = convertCurrency(amount, `${displayCurrency}/${currency}`)
+                  .toFixed(2);
+      }
 
       initialState = {
         amount,
@@ -140,9 +141,10 @@ export default class SendToAddress extends React.Component {
 
   send = async () => {
     let { toAddress, amount } = this.state;
-    let { toDollars, currencyDisplay } = this.props
+    let { convertCurrency, currencyDisplay } = this.props
 
-    amount = toDollars(amount);
+    const displayCurrency = localStorage.getItem("currency");
+    amount = convertCurrency(amount, `USD/${displayCurrency}`);
     console.log("CONVERTED TO DOLLAR AMOUNT",amount)
 
     if(this.state.canSend){

--- a/src/config.js
+++ b/src/config.js
@@ -2,7 +2,6 @@ const configs = [
   {
     DOMAINS: ["localhost", "10.0.0.107", "sundai.fritz.box", "192.168.178.25"],
     CURRENCY: {
-      EXCHANGE_RATE_QUERY: 5000,
       CURRENCY_LIST: ["EUR", "USD", "GBP"],
       DEFAULT_CURRENCY: "USD"
     },

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,6 @@
 const configs = [
   {
-    DOMAINS: ["localhost", "10.0.0.107", "sundai.fritz.box"],
+    DOMAINS: ["localhost", "10.0.0.107", "sundai.fritz.box", "192.168.178.25"],
     CURRENCY: {
       EXCHANGE_RATE_QUERY: 5000,
       CURRENCY_LIST: ["EUR", "USD", "GBP"],

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -54,7 +54,8 @@
       "to_address": "An Adresse",
       "send_amount": "Betrag senden",
       "notice": "Du kannst nur folgenden Betrag senden: ",
-      "error": "Bitte eine gültige Adresse oder ENS eingeben."
+      "error": "Bitte eine gültige Adresse oder ENS eingeben.",
+      "currency_error": "Bitte aktualisiere deine burner-wallet zu einer neuen Version die Währungsumrechnung unterstützt."
     },
     "send_by_scan": {
       "try_again": "Bitte versuchen Sie es erneut",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -54,7 +54,8 @@
       "to_address": "To Address",
       "send_amount": "Send Amount",
       "notice": "You can only send ",
-      "error": "Please enter a valid address or ENS."
+      "error": "Please enter a valid address or ENS.",
+      "currency_error": "Please update your burner-wallet to a newer version that supports currency conversion."
     },
     "send_by_scan": {
       "try_again": "Please try again",


### PR DESCRIPTION
Fixes #200 

TODOs:

- [x] Make exchangeRate function query all possible display currencies and rates and cache them
- [x] When two users with different display values do a "Request", display a warning that a conversion is happening
- [x] Display converted amount in SentToAddress.js
- [x] Make sure this fix is backward-compatible
- [x] Advanced.js "Display currency" is not showing all values anymore. Fix this
- [x] Conversion of € => $ in Bity.js for Amount is not correct ATM
- [x] rename `exchangeRate` to `exchangeRates`
- [x] `this.queryExchangeWithNativeCurrency` should just run once per e.g. day. Otherwise it's really confusing for the user

## Comment

In c3bde28 I simply removed querying/polling for the latest conversion rate. It's confusing to the user when they e.g. "Request" 3€ for a beer and in between the wallet just refreshes to a new exchange rate and now all of a sudden you request 3.10€.

Now, the wallet only fetches the exchange rate when loading.

## For testing

Setup your phone such that it uses a different display currency than the desktop wallet. Then e.g. try requesting an amount and check if the value is correctly converted.

Please note that if you use a QR code that is earlier than this PR, then it will not include the `currency` field and you'll get an error. This intended behavior.

## Problems

- [x] "Side element" to display currency in amount `input` to user => https://github.com/ConsenSys/rimble-ui/issues/337

