### PR TITLE
Allow regular expressions in config file

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,6 @@
 const configs = [
   {
-    DOMAINS: ["localhost", "10.0.0.107", "sundai.fritz.box", "192.168.178.25"],
+    DOMAINS: ["localhost", "10.0.0.107", "sundai.fritz.box", /192\.168\..*/, /.*\.ngrok\.io/],
     CURRENCY: {
       CURRENCY_LIST: ["USD", "EUR", "GBP"],
       DEFAULT_CURRENCY: "USD"
@@ -136,7 +136,12 @@ const configs = [
 ];
 
 function findConfig(hostname) {
-  return configs.filter(({ DOMAINS }) => DOMAINS.includes(hostname));
+  return configs.filter(
+    ({ DOMAINS }) =>
+      DOMAINS.filter(domain =>
+        domain instanceof RegExp ? domain.exec(hostname) : domain === hostname
+      ).length
+  );
 }
 
 export default function getConfig() {


### PR DESCRIPTION
See original: https://github.com/social-dist0rtion-protocol/planet-a/pull/19

Problem: testing the burner wallet in a local network requires to update
the configuration with the IP/hostname of the development server. My IP
changes depending on the network I'm in, and every time I get a new IP
address I have to update the config file to match it.
Moreover, if I want to test with ngrok my hostname changes all the times
I start the ngrok tunneling service.

Solution: local networks have specific IP ranges, so instead of pointing
to a specific IP address we can use a regexp to match all IPs in that
local network. We can extend this idea to all subdomains of ngrok.